### PR TITLE
ci: pass secret to job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,8 @@ jobs:
     defaults:
       run:
           working-directory: ./Zoomy-Zodiacs
+    env:
+      ZZ_DISCORD_BOT_TOKEN: ${{ secrets.ZZ_DISCORD_BOT_TOKEN }}
     steps:
       - run: echo "ZZ_DISCORD_BOT_TOKEN=$ZZ_DISCORD_BOT_TOKEN" >> .env
       - run: echo "$HOME/.local/bin" >> $GITHUB_PATH


### PR DESCRIPTION
The runner doesn't have the env var set.
So, this change should pass the secret from githubs secret manager to the run job.