### PR TITLE
ci: systemd

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Stop Server
         if: always()
-        run: kill $(cat pid.txt) || true
+        run: systemctl stop zz_bot || true
       - name: Clean Up
         if: always()
         run: cd ${{ github.workspace }}; rm -rf Zoomy-Zodiacs;
@@ -65,4 +65,6 @@ jobs:
       - run: echo "ZZ_DISCORD_BOT_TOKEN=$ZZ_DISCORD_BOT_TOKEN" >> .env
       - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Start Bot
-        run: pdm run ci
+        run: systemctl start zz_bot
+      - name: Stat Bot
+        run: systemctl status zz_bot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,6 @@ dev = ["ruff>=0.5.3", "pre-commit>=3.7.1", "pytest>=8.2.2"]
 test = { cmd = "python -m pytest" }
 
 start = { cmd = "python -m bot" }
-stop = { cmd = "kill $(cat pid.txt)" }
-
-# Start main, pipe output to a log file, and the pid to pid.txt
-ci = { cmd = "pdm run nohup python -m bot > bot.log 2>&1 & echo $! > pid.txt" }
 
 [tool.ruff]
 # Increase the line length. This breaks PEP8, but it is way easier to work with.


### PR DESCRIPTION
Ok, the hack where we try and thread to the background is no good. This change depends on system daemon instead.

The runner user has a polkit permission to access systemctl without sudo

This should allow the build runner to start a stable bot job